### PR TITLE
issue #39: added support for test-modules database

### DIFF
--- a/deploy/default.properties
+++ b/deploy/default.properties
@@ -59,6 +59,7 @@ content-forests-per-host=1
 # Leave commented out for no test db
 # turn it on if you are using the roxy unit tester
 # test-content-db=${app-name}-content-test
+# test-modules-db=${app-modules-db}
 
 # Leave commented out for default
 # schemas-db=${app-name}-schemas

--- a/deploy/sample/build.sample.properties
+++ b/deploy/sample/build.sample.properties
@@ -26,6 +26,7 @@ modules-root=/
 # turn these on if you are using the roxy unit tester
 #
 # test-content-db=${app-name}-content-test
+# test-modules-db=${app-name}-modules
 # test-port=8042
 
 #

--- a/deploy/sample/ml-config.sample.xml
+++ b/deploy/sample/ml-config.sample.xml
@@ -40,6 +40,7 @@
       <forest-name>@ml.content-db</forest-name>
     </assignment>
     @ml.test-content-db-assignment
+    @ml.test-modules-db-assignment
     <assignment>
       <forest-name>@ml.modules-db</forest-name>
     </assignment>
@@ -215,6 +216,8 @@
       <directory-creation>automatic</directory-creation>
       <maintain-last-modified>false</maintain-last-modified>
     </database>
+    <!--Create Test Modules Database-->
+    @ml.test-modules-db-xml
     <!--Create a Triggers Database-->
     @ml.triggers-db-xml
     @ml.schemas-db-xml


### PR DESCRIPTION
i think this covers all the bases for supporting a separate test-modules db. the original functionality is preserved if the ml.test-modules-db property isn't set, isn't present, or is set to the same value as the ml.modules-db property.
