### PR TITLE
add ch:get and use req:get to provide default value for ch:set-value

### DIFF
--- a/src/roxy/lib/controller-helper.xqy
+++ b/src/roxy/lib/controller-helper.xqy
@@ -94,6 +94,16 @@ declare function ch:set-value($key as xs:string, $value as item()*)
   map:put($ch:map, $key, $value)
 };
 
+declare function ch:set-value($key as xs:string)
+{
+  map:put($ch:map, $key, req:get($key))
+};
+
+declare function ch:get($key as xs:string)
+{
+  map:get($ch:map, $key)
+};
+
 declare function ch:set-format($new-format as xs:string)
 {
   ch:set-format($new-format, $ALL-FORMATS)


### PR DESCRIPTION
This should have been in the previous pull request. I'm not sure if `ch:get` is really necessary, but it didn't seem hygienic to call `map:get($ch:map...)` from another module.
