### PR TITLE
action credentials - set up user and password for an environment

### DIFF
--- a/deploy/lib/Help.rb
+++ b/deploy/lib/Help.rb
@@ -2,12 +2,13 @@ class Help
   def self.usage
     <<-DOC.strip_heredoc
 
-      Usage: ml COMMAND [ARGS]
+      Usage: ml ENVIRONMENT COMMAND [ARGS]
 
       Deployment Commands:
        init           Creates configuration files for you to customize
        initcpf        Creates cpf configuration files for you to customize
        info           Return settings for a given environment
+       credentials    Configures user and password for a given environment
        bootstrap      Configures your application on the MarkLogic server
        wipe           Remove your configuration from the MarkLogic server
        restart        Restart your MarkLogic server

--- a/deploy/lib/server_config.rb
+++ b/deploy/lib/server_config.rb
@@ -1066,4 +1066,38 @@ private
 
     properties = ServerConfig.substitute_properties(properties, properties, "ml.")
   end
+
+  def credentials()
+    logger.info "credentials #{@environment}"
+    # ml will error on invalid environment
+    # ask user for admin username and password
+    puts "What is the admin username?"
+    user = gets.chomp
+    puts "What is the admin password?"
+    # we don't want to install highline
+    # we can't rely on STDIN.noecho with older ruby versions
+    system "stty -echo"
+    password = gets.chomp
+    system "stty echo"
+
+    # Create or update environment properties file
+    filename = "#{@environment}.properties"
+    properties = {}
+    properties_file = File.expand_path("../#{filename}", __FILE__)
+    begin
+      properties = ServerConfig.load_properties(properties_file, "")
+    rescue => err
+      puts "Exception: #{err}"
+    end
+    properties["user"] = user
+    properties["password"] = password
+    open(properties_file, 'w') {
+      |f|
+      properties.each do |k,v|
+        f.write "#{k}=#{v}\n"
+      end
+    }
+    logger.info "wrote #{properties_file}"
+  end
+
 end


### PR DESCRIPTION
This patch adds a new 'credentials' action, which sets the admin username and password for a given environment. This is  meant for environments where the roxy application will be deployed without direct shell access by developers. A system admin can unpack the application archive and run `ml credentials` to set the admin user and password to values that are not shared with the application developers. In an environment like this, using `credentials` should be less error-prone than editing a file.

After implementing this in `app_specific` I thought it might be useful for other projects.
