### PR TITLE
fixed bug in facet-chiclet selection

### DIFF
--- a/src/app/views/helpers/facet-lib.xqy
+++ b/src/app/views/helpers/facet-lib.xqy
@@ -42,8 +42,7 @@ declare function facet:facets(
     for $facet at $index in $facets
     let $facet-name := fn:data($facet/@name)
     let $facet-count := fn:count($facet/search:facet-value)
-    let $match := fn:matches(fn:lower-case($qtext),fn:concat("^",fn:lower-case($facet-name)))
-      or fn:matches(fn:lower-case($qtext),fn:concat(" ",fn:lower-case($facet-name)))
+    let $match := fn:matches(fn:lower-case($qtext), fn:concat("(^|[ \(])",fn:lower-case($facet-name)))
     return
       <div class="category {fn:concat("category-",$index)} { if ($match) then "selected-category" else ()}">
         <h4 title="Collapse {trans:translate($facet-name, $labels, (), "en")} category">


### PR DESCRIPTION
facet selections preceded by parenthesis in a query were not being identified.
This new dynamic regex matches the beginning of a line OR (a space OR open parenthesis)
followed by the facet name.
