### PR TITLE
#263 don't double decode values from xdmp:get-request-field()

### DIFF
--- a/src/roxy/lib/request.xqy
+++ b/src/roxy/lib/request.xqy
@@ -38,7 +38,7 @@ declare variable $req:request as map:map :=
       for $val in xdmp:get-request-field($name)
     return
         if ($val instance of xs:anySimpleType) then
-          xdmp:url-decode($val)
+          $val
         else (
           if ($val instance of binary()) then
             map:put($map, fn:concat($name, "-filename"), xdmp:get-request-field-filename($name))


### PR DESCRIPTION
talked with @paxton about this one and i think it's safe to remove the xdmp:url-decode() since xdmp:get-request-field() already handles this.
