### PR TITLE
Fixed #664: capture and pass through exit code of mlcp, corb, etc

### DIFF
--- a/deploy/lib/server_config.rb
+++ b/deploy/lib/server_config.rb
@@ -1298,7 +1298,19 @@ In order to proceed please type: #{expected_response}
 
     runme = %Q{java -cp #{recordloader_file}#{path_separator}#{xcc_file}#{path_separator}#{xpp_file} #{prop_string} com.marklogic.ps.RecordLoader}
     logger.info runme
-    `#{runme}`
+    r = system(runme)
+    logger.debug $?
+
+    if r == nil
+      logger.error "Call to RecordLoader failed"
+      r = false
+    elsif !r
+      logger.error "RecordLoader non-zero exit"
+    else
+      logger.info ""
+    end
+
+    return r
   end
 
   def xqsync
@@ -1324,7 +1336,21 @@ In order to proceed please type: #{expected_response}
 
     runme = %Q{java -Xmx2048m -cp #{xqsync_file}#{path_separator}#{xcc_file}#{path_separator}#{xstream_file}#{path_separator}#{xpp_file} -Dfile.encoding=UTF-8 #{prop_string} com.marklogic.ps.xqsync.XQSync}
     logger.info runme
-    `#{runme}`
+
+    # Note: XQSync doesn't seem to exit with non-zero code at failure (yet), putting this in place nonetheless
+    r = system(runme)
+    logger.debug $?
+
+    if r == nil
+      logger.error "Call to XQSync failed"
+      r = false
+    elsif !r
+      logger.error "XQSync non-zero exit"
+    else
+      logger.info ""
+    end
+
+    return r
   end
 
   def corb
@@ -1386,9 +1412,6 @@ In order to proceed please type: #{expected_response}
       end
     end
 
-    # we have normalized the options, now clear the args
-    ARGV.clear
-
     # collect options and set as Java system properties switches
     systemProperties = options.delete_if{ |key, value| value.blank? }
                         .map{ |key, value| "-D#{key}=\"#{value}\""}
@@ -1406,11 +1429,24 @@ In order to proceed please type: #{expected_response}
       # directory, so that the xquery_modules will be visible with the
       # same path that will be used to see it in the modules database.
       Dir.chdir(@properties['ml.xquery.dir']) do
-        `#{runme}`
+        r = system(runme)
       end
     else
-      `#{runme}`
+      r = system(runme)
     end
+    logger.debug $?
+
+    if r == nil
+      logger.error "Call to Corb failed"
+      r = false
+    elsif !r
+      logger.error "Corb non-zero exit"
+    else
+      logger.info ""
+    end
+
+    ARGV.clear
+    return r
   end
 
   def mlcp
@@ -1490,12 +1526,20 @@ In order to proceed please type: #{expected_response}
       "PATH" => "#{ENV['PATH']};#{mlcp_home}\\bin",
       "HADOOP_HOME" => mlcp_home
     }
-    system(env_variables, runme)
+    r = system(env_variables, runme)
+    logger.debug $?
 
-    logger.info ""
+    if r == nil
+      logger.error "Call to MLCP failed"
+      r = false
+    elsif !r
+      logger.error "MLCP non-zero exit"
+    else
+      logger.info ""
+    end
 
     ARGV.clear
-    return true
+    return r
   end
 
   def credentials


### PR DESCRIPTION
Fixes #664.

The system call invokes sh, which in turn returns a 127 exit code if it cannot find java. The nil case is therefor never reached, but leaving it in place nonetheless. And at least it bails out in case Java is missing.

Side note: `./ml local mlcp version` exits with code 1 too, not sure why..