### PR TITLE
Fixed #757: return http 409 if failed, and use for exit code

### DIFF
--- a/deploy/lib/server_config.rb
+++ b/deploy/lib/server_config.rb
@@ -1297,12 +1297,25 @@ In order to proceed please type: #{expected_response}
         suites << line.gsub(/.*suite path="([^"]+)".*/, '\1').strip if line.match("suite path")
       end
 
+      success = true
       suites.each do |suite|
-        r = go(%Q{http://#{@hostname}:#{@properties["ml.test-port"]}/test/default.xqy?func=run&suite=#{url_encode(suite)}&format=junit#{suiteTearDown}#{testTearDown}}, "get")
-        logger.info r.body
+        begin
+          r = go(%Q{http://#{@hostname}:#{@properties["ml.test-port"]}/test/default.xqy?func=run&suite=#{url_encode(suite)}&format=junit#{suiteTearDown}#{testTearDown}}, "get")
+          logger.info r.body
+        rescue Net::HTTPServerException => e
+          if e.response.code.to_i == 409
+            # ignore 409's, but mark failure
+            success = false
+          else
+            raise # reraise last exception
+          end
+        end
       end
     end
-    return true
+    if !success
+      logger.error "Some tests failed!"
+    end
+    return success
   end
 
   def test_cleanup

--- a/src/test/default.xqy
+++ b/src/test/default.xqy
@@ -363,6 +363,10 @@ declare function local:run() {
   return
     if ($suite) then
       let $result := t:run-suite($suite, $tests, $run-suite-teardown, $run-teardown)
+      let $_ :=
+        if (fn:number($result/@failed) > 0) then
+          xdmp:set-response-code(409, "There are failed tests")
+        else ()
       return
         if ($format eq "junit") then
           local:format-junit($result)


### PR DESCRIPTION
Fixes #757