### PR TITLE
Fixed #692: leveraging search:parse to evaluate if's against properties

### DIFF
--- a/deploy/lib/server_config.rb
+++ b/deploy/lib/server_config.rb
@@ -761,12 +761,20 @@ but --no-prompt parameter prevents prompting for password.'
     logger.info r.body
   end
 
+  def properties_map
+    entries = []
+    @properties.each do |k, v|
+      entries.push %Q{map:entry("#{k}", "#{v}")}
+    end
+    "map:new((\n" + entries.join(",\n  ")+ "))"
+  end
+
   def config
     setup = File.read ServerConfig.expand_path("#{@@path}/lib/xquery/setup.xqy")
     r = execute_query %Q{
       #{setup}
       try {
-        setup:rewrite-config(#{get_config})
+        setup:rewrite-config(#{get_config}, #{properties_map})
       } catch($ex) {
         xdmp:log($ex),
         fn:concat($ex/err:format-string/text(), '&#10;See MarkLogic Server error log for more details.')
@@ -868,7 +876,7 @@ but --no-prompt parameter prevents prompting for password.'
     end
 
     setup = File.read(ServerConfig.expand_path("#{@@path}/lib/xquery/setup.xqy"))
-    r = execute_query %Q{#{setup} setup:do-setup(#{config}, "#{apply_changes},#{dointernals}")}
+    r = execute_query %Q{#{setup} setup:do-setup(#{config}, "#{apply_changes},#{dointernals}", #{properties_map})}
     logger.debug "code: #{r.code.to_i}"
 
     r.body = parse_body(r.body)
@@ -895,15 +903,13 @@ but --no-prompt parameter prevents prompting for password.'
     if internals == nil
       internals = ''
       logger.info "Cleaning application forest decommissioned replica state"
-      config = get_config
     else
       logger.info "Cleaning interal forest decommissioned replica state"
       internals = 'internals'
-      config = get_config
     end
 
     setup = File.read(ServerConfig.expand_path("#{@@path}/lib/xquery/setup.xqy"))
-    r = execute_query %Q{#{setup} setup:do-clean-replicas-state(#{config}, "#{internals}")}
+    r = execute_query %Q{#{setup} setup:do-clean-replicas-state("#{internals}")}
 
     if r.body.match("error log")
       logger.error r.body
@@ -930,7 +936,7 @@ but --no-prompt parameter prevents prompting for password.'
     end
 
     setup = File.read(ServerConfig.expand_path("#{@@path}/lib/xquery/setup.xqy"))
-    r = execute_query %Q{#{setup} setup:do-clean-replicas(#{config}, "#{internals}")}
+    r = execute_query %Q{#{setup} setup:do-clean-replicas(#{config}, "#{internals}", #{properties_map})}
     logger.debug "code: #{r.code.to_i}"
 
     r.body = parse_body(r.body)
@@ -1088,7 +1094,7 @@ In order to proceed please type: #{expected_response}
 
       }
     else
-      #logger.debug %Q{#{setup} setup:do-wipe(#{config})}
+      #logger.debug %Q{#{setup} setup:do-wipe(#{config}, #{properties_map})}
 
       wipe_changes = find_arg(['--apply-changes'])
 
@@ -1096,7 +1102,7 @@ In order to proceed please type: #{expected_response}
         wipe_changes = "all"
       end
 
-      r = execute_query %Q{#{setup} setup:do-wipe(#{config}, "#{wipe_changes}")}
+      r = execute_query %Q{#{setup} setup:do-wipe(#{config}, "#{wipe_changes}", #{properties_map})}
     end
     logger.debug "code: #{r.code.to_i}"
 
@@ -1128,7 +1134,7 @@ In order to proceed please type: #{expected_response}
     logger.info "Validating your project installation into MarkLogic on #{@hostname}..."
     setup = File.read(ServerConfig.expand_path("#{@@path}/lib/xquery/setup.xqy"))
     begin
-      r = execute_query %Q{#{setup} setup:validate-install(#{get_config})}
+      r = execute_query %Q{#{setup} setup:validate-install(#{get_config}, #{properties_map})}
       logger.debug "code: #{r.code.to_i}"
 
       r.body = parse_body(r.body)

--- a/deploy/lib/xquery/setup.xqy
+++ b/deploy/lib/xquery/setup.xqy
@@ -557,6 +557,7 @@ declare function setup:rewrite-config($import-configs as element(configuration)+
 
 declare function setup:rewrite-config($import-configs as element(configuration)+, $properties as map:map, $silent as xs:boolean?) as element(configuration)
 {
+  let $import-configs := setup:process-conditionals($import-configs, $properties)
   let $config :=
     element { fn:node-name($import-configs[1]) } {
       $import-configs/@*,
@@ -614,7 +615,7 @@ declare function setup:rewrite-config($import-configs as element(configuration)+
           fn:concat("No hosts assigned to group ", $group, ", needed for app servers and forests!"))
 
   (: all good :)
-  return setup:process-conditionals(setup:suppress-comments($config), $properties)
+  return setup:suppress-comments($config)
 };
 
 


### PR DESCRIPTION
Fixes #692.

Adds support to use an if attribute with a boolean expression on any config element, even the root (configuration). It allows expressions like:
- prop EQ val
- prop NE val
- prop LT val
- prop LE val
- prop GT val
- prop GE val
- -(prop EQ val)
- prop1 EQ val1 OR prop1 EQ val2
- prop1 EQ val1 AND prop2 EQ val2
- prop1 EQ val1 AND (prop2 EQ val2 OR prop2 EQ val2)
- prop1 EQ val1 AND -(prop2 EQ val2 OR prop2 EQ val2)
 
Minus represents NOT. For property names one uses the exact names from ml info, but without ml., nor @ or $. E.g.: `if="environment EQ local"`
