### PR TITLE
Fix a bug that breaks bootstraps of projects from ml new

### DIFF
--- a/deploy/sample/ml-config.sample.xml
+++ b/deploy/sample/ml-config.sample.xml
@@ -119,7 +119,6 @@
           <!-- <ssl-certificate-template>@ml.ssl-certificate-template</ssl-certificate-template> -->
         </http-server>
         @ml.test-appserver
-        @ml.rest-appserver
       </http-servers>
       <xdbc-servers>
         @ml.xdbc-server


### PR DESCRIPTION
Create a project with ./ml new

Bootstrap

It fails with ADMIN PORT IN USE

This fixes it. Wasn't caught by self test. Not sure when this broke. There may be a 'better' fix but I'm merging this to urgently fix the issue