### PR TITLE
Fixing Issue #604: missing support for geospatial-path-indexes

### DIFF
--- a/deploy/sample/ml-config.sample.xml
+++ b/deploy/sample/ml-config.sample.xml
@@ -304,7 +304,16 @@
         </range-path-index>
 -->
       </range-path-indexes>
-
+      <geospatial-region-path-indexes>
+<!--
+        <geospatial-region-path-index>
+          <path-expression>/foo/bar/geometry</path-expression>
+          <coordinate-system>wgs84</coordinate-system>
+          <geohash-precision>6</geohash-precision>
+          <invalid-values>reject</invalid-values>
+        </geospatial-region-path-index>
+-->
+      </geospatial-region-path-indexes>
       <geospatial-element-indexes>
 <!--
         <geospatial-element-index>

--- a/deploy/sample/ml-config.sample.xml
+++ b/deploy/sample/ml-config.sample.xml
@@ -304,6 +304,19 @@
         </range-path-index>
 -->
       </range-path-indexes>
+      
+      <geospatial-path-indexes>
+<!--
+        <geospatial-path-index>
+          <path-expression>/foo/bar/geometry</path-expression>
+          <coordinate-system>wgs84</coordinate-system>
+          <point-format>point</point-format>
+          <range-value-positions>false</range-value-positions>
+          <invalid-values>reject</invalid-values>
+        </geospatial-path-index>
+-->
+      </geospatial-path-indexes>
+    
       <geospatial-region-path-indexes>
 <!--
         <geospatial-region-path-index>


### PR DESCRIPTION
Added code to add geospatial-path-indexes and geospatial-region-path indexes.  Code checks for the server version >= 8.0.0 for geospatial-path-index and server version >= 9.0-1 for geospatial-region-path-index and otherwise follows the convention for all other indexes for validate, create, remove, etc functionality.  Tested on a live project. #604