### PR TITLE
Switch the xcc port to https if https is enabled.

### DIFF
--- a/deploy/default.properties
+++ b/deploy/default.properties
@@ -202,6 +202,11 @@ use-https=false
 #
 use-https-for-rest=false
 
+#
+# set this to true if you are using https for your xcc servers
+#
+use-https-for-xcc=false
+
 ## Security
 #
 # The authentication used for your appserver

--- a/deploy/lib/server_config.rb
+++ b/deploy/lib/server_config.rb
@@ -2451,7 +2451,8 @@ private
           :http_connection_retry_count => @properties["ml.http.retry-count"].to_i,
           :http_connection_open_timeout => @properties["ml.http.open-timeout"].to_i,
           :http_connection_read_timeout => @properties["ml.http.read-timeout"].to_i,
-          :http_connection_retry_delay => @properties["ml.http.retry-delay"].to_i
+          :http_connection_retry_delay => @properties["ml.http.retry-delay"].to_i,
+          :use_https_for_xcc => @properties["ml.use-https-for-xcc"] == "true"
         })
       end
   end

--- a/deploy/lib/xcc.rb
+++ b/deploy/lib/xcc.rb
@@ -100,6 +100,7 @@ module Roxy
       })
       @request = {}
       @gmt_offset = Time.now.gmt_offset
+      @xcc_protocol = "http#{options[:use_https_for_xcc] ? 's' : ''}"
     end
 
     def xcc_query(options)
@@ -176,7 +177,7 @@ private
     end
 
     def build_load_uri(target_uri, options, commit)
-      url = "http://#{@hostname}:#{@port}/insert?"
+      url = "#{@xcc_protocol}://#{@hostname}:#{@port}/insert?"
 
       url << "uri=#{url_encode(target_uri)}"
 


### PR DESCRIPTION
When building the url to talk to the xcc port roxy doesn't look whether that should be https or not,
it's just hardcoded to http, which makes it impossible to deploy modules. This commit changes that
by switching to https if either `use-https-for-rest` is set to true or `ssl-certificate-template`
exists in the config.

First attempt at fixing #862 
